### PR TITLE
Address issue where mount would fail when password had special characters

### DIFF
--- a/jss/distribution_points.py
+++ b/jss/distribution_points.py
@@ -413,7 +413,7 @@ class AFPDistributionPoint(MountedRepository):
         """Helper method for building mount URL strings."""
         if self.connection.get('username') and self.connection.get('password'):
             auth = "%s:%s@" % (self.connection['username'],
-                               urllib.quote(self.connection['password']))
+                               urllib.quote(unicode(self.connection['password']).encode('utf-8'),safe='~()*!.\''))
         else:
             auth = ''
 
@@ -452,7 +452,7 @@ class SMBDistributionPoint(MountedRepository):
         # Build auth string
         if self.connection.get('username') and self.connection.get('password'):
             auth = "%s:%s@" % (self.connection['username'],
-                               urllib.quote(self.connection['password']))
+                               urllib.quote(unicode(self.connection['password']).encode('utf-8'),safe='~()*!.\''))
             if self.connection.get('domain'):
                 auth = r"%s;%s" % (self.connection['domain'], auth)
         else:


### PR DESCRIPTION
Hey Shea,
Got another small PR for you.  

We were getting a number of reports where the AFP mount was failing, and we tracked it down.  The problem was many of the passwords had special characters in them (and specifically @ signs), which would cause the mount -t afp .... call to fail.   

https://github.com/lindegroup/autopkgr/issues/177
https://github.com/lindegroup/autopkgr/issues/176

This should address that issue by using `urllib.quote()` to percent encode the password.  

I've tested with AFP, but not SMB (i don't have access to an smb server).
Also I haven't tested on an actual JSS since I don't manage any, but in concept it should work fine.

--Eldon
