### PR TITLE
use TLSv1 instead of SSLv23, as JSS 9.61 requires

### DIFF
--- a/jss/contrib/requests/packages/urllib3/util/ssl_.py
+++ b/jss/contrib/requests/packages/urllib3/util/ssl_.py
@@ -9,7 +9,7 @@ try:  # Test for SSL features
     HAS_SNI = False
 
     import ssl
-    from ssl import wrap_socket, CERT_NONE, PROTOCOL_SSLv23
+    from ssl import wrap_socket, CERT_NONE, PROTOCOL_TLSv1
     from ssl import SSLContext  # Modern SSL?
     from ssl import HAS_SNI  # Has SNI?
 except ImportError:
@@ -80,7 +80,7 @@ def resolve_ssl_version(candidate):
     like resolve_cert_reqs
     """
     if candidate is None:
-        return PROTOCOL_SSLv23
+        return PROTOCOL_TLSv1
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)


### PR DESCRIPTION
JSS 9.61 dropped SSLv3 Support to be aware of the Poodle attack. We now use TLSv1 instead. This fix may could be done upstream on urllib3, but probably break other things.
