### PR TITLE
use request module in .contrib

### DIFF
--- a/jss/casper.py
+++ b/jss/casper.py
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 import copy
-import requests
+from .contrib import requests
 import urllib
 from xml.etree import ElementTree
 

--- a/jss/distribution_points.py
+++ b/jss/distribution_points.py
@@ -27,7 +27,7 @@ import shutil
 import subprocess
 
 import casper
-import requests
+from .contrib import requests
 
 
 PKG_TYPES = ['.PKG', '.DMG']


### PR DESCRIPTION
this issue just in https://github.com/lindegroup/autopkgr/issues/186

looks like it's not finding requests module unless the following is used in casper.py and distribution_points.py

```
from .contrib import requests
```
