### PR TITLE
make name optional with custom DP's

### DIFF
--- a/jss/distribution_points.py
+++ b/jss/distribution_points.py
@@ -125,7 +125,7 @@ class DistributionPoints(object):
 
                 # Handle Explictly declared DP's.
                 elif repo.get('type') in ['AFP', 'SMB']:
-                    name = repo['name']
+                    name = repo.get('name') or ''
                     URL = repo['URL']
                     connection_type = repo['type']
                     share_name = repo['share_name']


### PR DESCRIPTION
I noticed that in the jss-autopkg-addon [README.md](https://github.com/sheagcraig/jss-autopkg-addon/blob/JDS-update/README.md) for the JDS-update branch it indicated that the "name" key is optional, but it was raising if left unspecified in the preference.

I wasn't sure if you wanted to set an alternate default value like "JSS_DP_" to protect against mount_point clashes with casper admin, if so let me know and I'd be happy to update this PR.

Thanks,
Eldon
