### PR TITLE
Feature/uapi

### DIFF
--- a/jss/__init__.py
+++ b/jss/__init__.py
@@ -64,7 +64,7 @@ from .jssobject import JSSObject
 from .jssobjects import *
 from .jss_prefs import JSSPrefs
 from .misc_endpoints import *
-from .uapi_endpoints import *
+from .misc_uapi_endpoints import *
 from .queryset import QuerySet
 from .pretty_element import PrettyElement
 

--- a/jss/__init__.py
+++ b/jss/__init__.py
@@ -64,6 +64,7 @@ from .jssobject import JSSObject
 from .jssobjects import *
 from .jss_prefs import JSSPrefs
 from .misc_endpoints import *
+from .uapi_endpoints import *
 from .queryset import QuerySet
 from .pretty_element import PrettyElement
 

--- a/jss/auth.py
+++ b/jss/auth.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Copyright (C) 2014-2017 Shea G Craig
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import requests
+from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class UAPIAuth(requests.auth.AuthBase):
+
+    def __init__(self, username, password, fetch_url='/uapi/auth/tokens', token=None, expires=None):
+        self.username = username
+        self.password = password
+        self.token = token
+        self.expires = expires if expires else datetime.now()
+        self.fetch_url = fetch_url
+
+    def __call__(self, r):  # type: (requests.PreparedRequest) -> requests.PreparedRequest
+        if self.expires is not None and self.expires < datetime.now():
+            logger.debug("Token expiry has passed, fetching a new token.")
+            self._get_token()
+
+        r.headers['Authorization'] = 'jamf-token {}'.format(self.token)
+        r.register_hook('response', self.handle_401)
+        return r
+
+    def _get_token(self):
+        r = requests.post(self.fetch_url, auth=(self.username, self.password), verify=False)
+        r.raise_for_status()
+        data = r.json()
+
+        self.token = data['token']
+        #self.expires = datetime.utcfromtimestamp(data['expires'])
+
+    def handle_401(self, r, **kwargs):  # type: (requests.Response, dict) -> requests.Response
+        """
+        Takes the given response, fetches a new token, and retries
+        :param r:
+        :param kwargs:
+        :return:
+        """
+        if r.status_code is not 401:
+            return r
+
+        logger.debug("Server returned HTTP 401, getting a new token")
+        self._get_token()
+
+
+
+

--- a/jss/jamf_software_server.py
+++ b/jss/jamf_software_server.py
@@ -28,6 +28,7 @@ import re
 import json
 from xml.etree import ElementTree
 import requests
+from UserDict import UserDict
 
 # from jss.nsurlsession_adapter import NSURLSessionAdapter
 from .curl_adapter import CurlAdapter
@@ -354,6 +355,9 @@ class JSS(object):
         elif isinstance(data, dict):
             data = json.dumps(data)
             headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+        elif isinstance(data, UserDict):
+            data = json.dumps(data.data)
+            headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
         else:
             headers = {'Content-Type': 'application/octet-stream', 'Accept': '*/*'}
 
@@ -396,6 +400,9 @@ class JSS(object):
             headers = {'Content-Type': 'text/xml', 'Accept': 'text/xml'}
         elif isinstance(data, dict):
             data = json.dumps(data)
+            headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+        elif isinstance(data, UserDict):
+            data = json.dumps(data.data)
             headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
         else:
             raise TypeError('Could not PUT unrecognised data type')

--- a/jss/jamf_software_server.py
+++ b/jss/jamf_software_server.py
@@ -70,6 +70,48 @@ class JSS(object):
                 positive number: Number of seconds to keep.
     """
 
+    class UAPI(object):
+        """This object represents the UAPI. All UAPI search methods will be attached here."""
+        def __init__(self, jss, url=None):
+            self.jss = jss
+            self._base_url = url
+
+        @property
+        def base_url(self):
+            """The URL to the Casper JSS, including port if needed."""
+            return self._base_url
+
+        @base_url.setter
+        def base_url(self, url):
+            """The URL to the Casper JSS, including port if needed."""
+            # Remove the frequently included yet incorrect trailing slash.
+            self._base_url = url.rstrip("/")
+
+        @property
+        def url(self):  # type: () -> str
+            return "%s/%s" % (self.base_url, "uapi")
+
+    class JSSAPI(object):
+        """This object represents the XML API. All regular API search methods will be attached here."""
+        def __init__(self, jss, url=None):
+            self.jss = jss
+            self._base_url = url
+
+        @property
+        def base_url(self):
+            """The URL to the Casper JSS, including port if needed."""
+            return self._base_url
+
+        @base_url.setter
+        def base_url(self, url):
+            """The URL to the Casper JSS, including port if needed."""
+            # Remove the frequently included yet incorrect trailing slash.
+            self._base_url = url.rstrip("/")
+
+        @property
+        def url(self):  # type: () -> str
+            return "%s/%s" % (self.base_url, "JSSResource")
+
     # pylint: disable=too-many-arguments
     def __init__(
         self, jss_prefs=None, url=None, user=None, password=None,
@@ -150,15 +192,16 @@ class JSS(object):
         self.ssl_verify = ssl_verify
 
         self.distribution_points = distribution_points.DistributionPoints(self)
-
         self.max_age = -1
+        self.uapi = JSS.UAPI(self, url)
+        self.api = JSS.JSSAPI(self, url)
 
     # pylint: disable=too-many-arguments
 
     @property
     def _url(self):
         """The URL to the Casper JSS API endpoints. Get only."""
-        return "%s/%s" % (self.base_url, "JSSResource")
+        return self.api.url
 
     @property
     def base_url(self):
@@ -689,8 +732,8 @@ def add_uapi_search_method(cls, name):
         """
         if not isinstance(data, dict):
             url = obj_type.build_query(data, **kwargs)
-            data = self.get(url, headers={'Content-Type': 'application/json', 'Accept': 'application/json'},
-                            auth=UAPIAuth(self.user, self.password, "{}/uapi/auth/tokens".format(self.base_url)))
+            data = self.jss.get(url, headers={'Content-Type': 'application/json', 'Accept': 'application/json'},
+                            auth=UAPIAuth(self.jss.user, self.jss.password, "{}/uapi/auth/tokens".format(self.jss.base_url)))
 
         if isinstance(data, list):
             return [obj_type(self, d) for d in data]
@@ -715,7 +758,8 @@ for jss_class in jssobjects.__all__:
     add_search_method(JSS, jss_class)
 
 for jss_uapi_class in uapiobjects.__all__:
-    add_uapi_search_method(JSS, jss_uapi_class)
+    print(jss_uapi_class)
+    add_uapi_search_method(JSS.UAPI, jss_uapi_class)
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods
 

--- a/jss/jamf_software_server.py
+++ b/jss/jamf_software_server.py
@@ -31,10 +31,10 @@ import requests
 
 from jss.nsurlsession_adapter import NSURLSessionAdapter
 from . import distribution_points
-from .curl_adapter import CurlAdapter
 from .exceptions import GetError, PutError, PostError, DeleteError
 from .jssobject import JSSObject
 from . import jssobjects
+from . import uapiobjects
 from .queryset import QuerySet
 from .tools import error_handler, quote_and_encode
 
@@ -231,8 +231,8 @@ class JSS(object):
         self.user, self.password = auth
         self.ssl_verify = ssl_verify
 
-    def get(self, url_path):
-        # type: (str) -> Union[ElementTree.Element, dict]
+    def get(self, url_path, headers=None):
+        # type: (str) -> Union[ElementTree.Element, dict, bytes]
         """GET a url, handle errors, and return an etree.
 
         In general, it is better to use a higher level interface for
@@ -241,9 +241,12 @@ class JSS(object):
 
         Args:
             url_path: String API endpoint path to GET (e.g. "packages")
+            headers: [Optional] headers to add to the request
 
         Returns:
-            ElementTree.Element for the XML returned from the JSS.
+            ElementTree.Element for the XML returned from the JSS if the response was XML,
+            dict if the response had Content-Type for json,
+            bytes for anything else
 
         Raises:
             GetError if provided url_path has a >= 400 response, for
@@ -253,8 +256,11 @@ class JSS(object):
             This behavior will change in the future for 404/Not Found
             to returning None.
         """
-        request_url = os.path.join(self._url, quote_and_encode(url_path))
-        response = self.session.get(request_url, headers={'Content-Type': 'text/xml', 'Accept': 'text/xml'})
+        request_url = os.path.join(self.base_url, quote_and_encode(url_path))
+        if headers is None:  # Fall back to XML to support python-jss prior to addition of UAPI
+            headers = {'Content-Type': 'text/xml', 'Accept': 'text/xml'}
+
+        response = self.session.get(request_url, headers=headers)
 
         if response.status_code == 200 and self.verbose:
             print "GET %s: Success." % request_url
@@ -268,10 +274,12 @@ class JSS(object):
                 return xmldata
             except ElementTree.ParseError:
                 raise GetError("Error Parsing XML:\n%s" % response.content)
+        elif response.headers['content-type'] == 'application/json':
+            return response.json()
         else:
-            raise TypeError('Unimplemented')
+            return response.content
 
-    def post(self, url_path, data):
+    def post(self, url_path, data=None):
         # type: (str, Union[ElementTree.Element, dict]) -> str
         """POST an object to the JSS. For creating new objects only.
 
@@ -291,7 +299,7 @@ class JSS(object):
         """
         # The JSS expects a post to ID 0 to create an object
 
-        request_url = os.path.join(self._url, quote_and_encode(url_path))
+        request_url = os.path.join(self.base_url, quote_and_encode(url_path))
         headers = {}
 
         if isinstance(data, ElementTree.Element):
@@ -300,8 +308,6 @@ class JSS(object):
         elif isinstance(data, dict):
             data = json.dumps(data)
             headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
-        else:
-            raise TypeError('Could not POST unrecognised data type')
 
         response = self.session.post(request_url, data=data, headers=headers)
 
@@ -334,7 +340,7 @@ class JSS(object):
         Raises:
             PutError if provided url_path has a >= 400 response.
         """
-        request_url = os.path.join(self._url, quote_and_encode(url_path))
+        request_url = os.path.join(self.base_url, quote_and_encode(url_path))
         headers = {}
 
         if isinstance(data, ElementTree.Element):
@@ -369,7 +375,7 @@ class JSS(object):
         Raises:
             DeleteError if provided url_path has a >= 400 response.
         """
-        request_url = os.path.join(self._url, quote_and_encode(url_path))
+        request_url = os.path.join(self.base_url, quote_and_encode(url_path))
         if data:
             data = ElementTree.tostring(data, encoding='UTF-8')
             response = self.session.delete(request_url, data=data,
@@ -618,12 +624,99 @@ def add_search_method(cls, name):
     setattr(cls, name, api_method)
 
 
+# TODO: DRY.. this is just a temp copy/paste to try abstracting
+def add_uapi_search_method(cls, name):
+    """Add a class-specific search method to a class (JSS)"""
+    # Get the actual class to search for, from str `name`
+    obj_type = getattr(uapiobjects, name)
+
+    # Create a closure over the retrieved class to do our search.
+    def api_method(self, data=None, **kwargs):
+        """Flexibly search the JSS for objects of type {0}.
+
+            Args:
+                data (None, int, str, xml.etree.ElementTree.Element):
+                    Argument to query for. Different queries are
+                    performed depending on the type of this arg:
+                        None (or provide no argument / default):
+                            Search for all objects.
+                        int: Search for an object by ID.
+                        str: Search for an object by name. Some objects
+                            allow 'match' searches, using '*' as the
+                            wildcard operator.
+                        xml.etree.ElementTree.Element: create a new
+                            object from the Element's data.
+                kwargs:
+                    {1}
+
+                    Some classes allow additional filters, subsets, etc,
+                    in their queries. Check the object's `allowed_kwargs`
+                    attribute for a complete list of implemented keys.
+
+                    Not all classes offer all types of searches, nor are
+                    they all necessarily offered in a single query.
+                    Consult the Casper API documentation for usage.
+
+                    In general, the key name is applied to the end of the
+                    URL, followed by the val; e.g.
+                    '<url>/subset/general'.
+
+                    Some common types of extra arguments:
+
+                    subset (list of str or str): XML subelement tags to
+                        request (e.g.  ['general', 'purchasing']), OR an
+                        '&' delimited string (e.g.
+                        'general&purchasing').  Defaults to None.
+                    start_date/end_date (str or datetime): Either dates
+                        in the form 'YYYY-MM-DD' or a datetime.datetime
+                        object.
+
+            Returns:
+                QuerySet: If data=None, return all objects of this
+                    type.
+                {0}: If searching or creating new objects, return an
+                    instance of that object.
+                None: (FUTURE) Will return None if nothing is found that
+                    matches the search criteria.
+
+            Raises:
+                GetError for nonexistent objects.
+        """
+        if not isinstance(data, ElementTree.Element):
+            url = obj_type.build_query(data, **kwargs)
+            data = self.get(url)
+
+        # TODO: Deprecated and pending removal
+        if hasattr(obj_type, "container"):
+            data = data.find(obj_type.container)
+
+        if data.find("size") is not None:
+            return QuerySet.from_response(obj_type, data, self, **kwargs)
+        else:
+            return obj_type(self, data)
+
+    # Add in the missing variables to the docstring and set name.
+    if hasattr(obj_type, 'allowed_kwargs') and obj_type.allowed_kwargs:
+        allowed = ', '.join(obj_type.allowed_kwargs)
+        msg = 'Allowed keyword arguments for this class are:\n{}{}'
+        kwarg_doc = msg.format(6 * "    ", allowed) if allowed else ""
+    else:
+        kwarg_doc = "(None supported)"
+    api_method.__doc__ = api_method.__doc__.format(name, kwarg_doc)
+    api_method.__name__ = name
+    # Add the method to the class with the correct name.
+    setattr(cls, name, api_method)
+
+
 # Run `add_search_method` against everything that jss.jssobjects exports.
 for jss_class in jssobjects.__all__:
     add_search_method(JSS, jss_class)
 
+for jss_uapi_class in uapiobjects.__all__:
+    add_uapi_search_method(JSS, jss_uapi_class)
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods
+
 
 class JSSObjectFactory(object):
     """Deprecated"""

--- a/jss/jssobject.py
+++ b/jss/jssobject.py
@@ -108,7 +108,7 @@ class JSSObject(PrettyElement):
         Returns:
             str path construction for this class to query.
         """
-        return cls._endpoint_path
+        return 'JSSResource/%s' % cls._endpoint_path
 
     @property
     def url(self):
@@ -117,7 +117,7 @@ class JSSObject(PrettyElement):
         For example: "/activationcode"
         """
         # Flat objects have no ID property, so there is only one URL.
-        return self._endpoint_path
+        return 'JSSResource/%s' % self._endpoint_path
 
     def __repr__(self):
         if isinstance(self.cached, dt.datetime):
@@ -432,7 +432,7 @@ class Container(JSSObject):
         Returns:
             str path construction for this class to query.
         """
-        url_components = [cls._endpoint_path]
+        url_components = ['JSSResource', cls._endpoint_path]
 
         try:
             data = int(data)
@@ -509,7 +509,7 @@ class Container(JSSObject):
 
         For example: "computers/id/451"
         """
-        url_components = [self._endpoint_path, self._id_path, self.id]
+        url_components = ['JSSResource', self._endpoint_path, self._id_path, self.id]
         url_components.extend(self._process_kwargs(self.kwargs))
         return os.path.join(*url_components)
 

--- a/jss/misc_uapi_endpoints.py
+++ b/jss/misc_uapi_endpoints.py
@@ -44,3 +44,16 @@ class SystemInitialize(object):
     def initialize(self, data):
         r = self.jss.post(self.url, data)
 
+
+class RecalculateComputerSmartGroups(object):
+    _endpoint_path = "computer/obj/computer"
+    can_get = False
+    can_put = False
+    can_delete = False
+
+
+class RecalculateSmartGroupComputers(object):
+    _endpoint_path = "computer/obj/smartgroup"
+    can_get = False
+    can_put = False
+    can_delete = False

--- a/jss/uapi_endpoints.py
+++ b/jss/uapi_endpoints.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Copyright (C) 2014-2017 Shea G Craig
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""uapi.py
+
+Classes representing UAPI endpoints that are more RPC style than CRUD.
+"""
+
+
+__all__ = ('AuthToken')
+

--- a/jss/uapi_endpoints.py
+++ b/jss/uapi_endpoints.py
@@ -19,5 +19,28 @@ Classes representing UAPI endpoints that are more RPC style than CRUD.
 """
 
 
-__all__ = ('AuthToken')
+__all__ = 'SystemInitialize',
+
+
+class SystemInitialize(object):
+    _endpoint_path = "system/initialize"
+    can_get = False
+    can_put = False
+    can_delete = False
+
+    def __init__(self, jss):
+        """Initialize a new SystemInitialize
+
+        Args:
+            jss: JSS object.
+        """
+        self.jss = jss
+
+    @property
+    def url(self):
+        """Return the path subcomponent of the url to this object."""
+        return self._endpoint_path
+
+    def initialize(self, data):
+        r = self.jss.post(self.url, data)
 

--- a/jss/uapiobject.py
+++ b/jss/uapiobject.py
@@ -23,13 +23,14 @@ import datetime as dt
 import json
 
 import tools
+from UserDict import UserDict
 from .exceptions import JSSError, MethodNotAllowedError, PutError, PostError
 
 
 DATE_FMT = "%Y/%m/%d-%H:%M:%S.%f"
 
 
-class UAPIObject(dict):
+class UAPIObject(UserDict):
     """Subclass for JSS UAPI objects which do not return a list of objects.
 
     These objects have in common that they cannot be created. They can,
@@ -59,10 +60,10 @@ class UAPIObject(dict):
             kwargs: Unused, but present to support a unified signature
                 for all subclasses (which need and use kwargs).
         """
+        UserDict.__init__(self, data)
         self.jss = jss
         self.cached = False
-
-        super(UAPIObject, self).__init__(data)
+        #super(UAPIObject, self).__init__(data)
 
     @property
     def cached(self):  # type: () -> bool
@@ -224,7 +225,7 @@ class UAPIContainer(UAPIObject):
 
         elif isinstance(data, dict):
             # Create a new object from passed XML.
-            super(UAPIContainer, self).__init__(jss, data)
+            UAPIObject.__init__(self, jss, data, **kwargs)
             # If this has an ID, assume it's from the JSS and set the
             # cache time, otherwise set it to "Unsaved".
             if 'id' in data and data['id']:

--- a/jss/uapiobject.py
+++ b/jss/uapiobject.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+# Copyright (C) 2014-2017 Shea G Craig
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""uapiobject.py
+
+Base Classes representing JSS database objects and their UAPI endpoints
+"""
+
+import os
+import datetime as dt
+import json
+
+import tools
+from .exceptions import JSSError, MethodNotAllowedError, PutError, PostError
+
+
+DATE_FMT = "%Y/%m/%d-%H:%M:%S.%f"
+
+
+class UAPIObject(dict):
+    """Subclass for JSS UAPI objects which do not return a list of objects.
+
+    These objects have in common that they cannot be created. They can,
+    however, be updated.
+
+    Class Attributes:
+        cached: False, or datetime.datetime since last retrieval.
+        can_get: Bool whether object allows a GET request.
+        can_put: Bool whether object allows a PUT request.
+        can_post: Bool whether object allows a POST request.
+        can_delete: Bool whether object allows a DEL request.
+    """
+    _endpoint_path = None  # type: Optional[str]
+    can_get = True         # type: bool
+    can_put = True         # type: bool
+    can_post = False       # type: bool
+    can_delete = False     # type: bool
+
+    def __init__(self, jss, data, **kwargs):
+        # type: (JSS, Optional[dict], Optional[dict]) -> None
+        """Initialize a new UAPIObject
+
+        Args:
+            jss (JSS, None): JSS to get data from, or None if no JSS
+                communications need to be performed.
+            data: dict data for the object
+            kwargs: Unused, but present to support a unified signature
+                for all subclasses (which need and use kwargs).
+        """
+        self.jss = jss
+        self.cached = False
+
+        super(UAPIObject, self).__init__(data)
+
+    @property
+    def cached(self):  # type: () -> bool
+        # Check to see whether cache should be invalidated due to age.
+        # If jss.max_age is 0, never cache.
+        # If jss.max_age is negative, cache lasts forever.
+        if isinstance(self._cached, dt.datetime) and self.jss.max_age > -1:
+            max_age = dt.timedelta(seconds=self.jss.max_age)
+            now = dt.datetime.now()
+            if now - self._cached > max_age:
+                self._cached = False
+
+        return self._cached
+
+    @cached.setter
+    def cached(self, val):  # type: (bool) -> None
+        self._cached = val
+
+    @classmethod
+    def build_query(cls, *args, **kwargs):
+        # type: (Optional[List[any]], Optional[dict]) -> str
+        """Return the path for query based on data type and contents.
+
+        Args:
+            *args, **kwargs: Left for compatibility with more
+            full-featured subclasses' overrides.
+
+        Returns:
+            str path construction for this class to query.
+        """
+        return 'uapi/%s' % cls._endpoint_path
+
+    @property
+    def url(self):  # type: () -> str
+        """Return the path subcomponent of the url to this object.
+
+        For example: "/activationcode"
+        """
+        # Flat objects have no ID property, so there is only one URL.
+        return 'uapi/%s' % self._endpoint_path
+
+    def __repr__(self):
+        if isinstance(self.cached, dt.datetime):
+            cached = self.cached.strftime(DATE_FMT)
+        else:
+            cached = bool(self.cached)
+        return "<{} cached: {} at 0x{:0x}>".format(
+            self.__class__.__name__, cached, id(self))
+
+    def retrieve(self):
+        """Replace this object's data with JSS data, reset cache-age."""
+        if self.jss.verbose:
+            print "Retrieving data from JSS..."
+
+        json_data = self.jss.get(self.url, headers={'Accept': 'application/json'})
+        self.update(json_data)
+        self.cached = dt.datetime.now()
+
+    def save(self):
+        """Update or create a new object on the JSS.
+
+        If this object is not yet on the JSS, this method will create
+        a new object with POST, otherwise, it will try to update the
+        existing object with PUT.
+
+        Data validation is up to the client; The JSS in most cases will
+        at least give you some hints as to what is invalid.
+        """
+        try:
+            self.jss.put(self.url, data=self)
+        except PutError as put_error:
+            # Something when wrong.
+            raise PutError(put_error)
+
+        # Replace current instance's data with new, JSS-validated data.
+        self.retrieve()
+
+    def to_file(self, path):
+        """Write object JSON to path.
+
+        Args:
+            path: String file path to the file you wish to (over)write.
+                Path will have ~ expanded prior to opening.
+        """
+        with open(os.path.expanduser(path), "w") as ofile:
+            ofile.write(json.dumps(self))
+
+    def to_string(self):
+        """Return indented object JSON as bytes."""
+        return self.__str__()
+
+
+class UAPIContainer(UAPIObject):
+    """Subclass for members of a type of UAPI object.
+
+    Class Attributes:
+        cached: False, "Unsaved" for newly created objects that have
+            not been POSTed to the JSS, or datetime.datetime since last
+            retrieval.
+        kwargs (dict): Keyword argument dictionary used in the original
+            GET request to retrieve this object. By default, kwargs are
+            applied to subsequent `retrieve()` operations unless
+            cleared.
+        can_get: Bool whether object allows a GET request.
+        can_put: Bool whether object allows a PUT request.
+        can_post: Bool whether object allows a POST request.
+        can_delete: Bool whether object allows a DEL request.
+        default_search: String default search type to utilize for GET.
+        search_types: Dict of search types available to object:
+            Key: Search type name. At least one must match the
+                default_search.
+            Val: URL component to use to request via this search_type.
+        allowed_kwargs: Tuple of query extensions that are
+            available (or sometimes required). Please see the JAMF Pro
+            API documentation for the final word on how these work.
+        data_keys: Dictionary of keys to create if instantiating a
+            blank object using the _new method.
+            Keys: String names of keys to create at top level.
+            Vals: Values to set for the key.
+                Int and bool values get converted to string.
+                Dicts are recursively added (so their keys are added to
+                    parent key, etc).
+
+    Private Class Attributes:
+        _id_path (str): URL Path subcomponent used to reference an
+            object by ID when querying or posting.
+    """
+    can_get = True
+    can_put = True
+    can_post = True
+    can_delete = True
+    default_search = "name"  # type: str
+    search_types = {"name": "name"}  # type: dict
+    allowed_kwargs = tuple()  # type: Tuple[str]
+    data_keys = {}  # type: dict
+    _id_path = "id"  # type: str
+
+    # Overrides ###############################################################
+    def __init__(self, jss, data, **kwargs):
+        """Initialize a new JSSObject from scratch or from a python dict.
+
+        Args:
+            jss (JSS, None): JSS object, or None if no communication
+                with the JSS is needed.
+            data (xml.etree.ElementTree.Element, Identity, str): XML
+                data to use for creating the object, a name to use for
+                creating a new object, or an Identity object reprsenting
+                basic object info.
+            kwargs (str): Key/value pairs to be added to the object when
+                building one from scratch.
+        """
+        self.jss = jss
+        # self._basic_identity = Identity(name="", id="")
+        self.kwargs = {}
+
+        if isinstance(data, basestring):
+            self._new(data, **kwargs)
+            self.cached = "Unsaved"
+
+        elif isinstance(data, dict):
+            # Create a new object from passed XML.
+            super(UAPIContainer, self).__init__(jss, data)
+            # If this has an ID, assume it's from the JSS and set the
+            # cache time, otherwise set it to "Unsaved".
+            if 'id' in data and data['id']:
+                self.cached = dt.datetime.now()
+            else:
+                self.cached = "Unsaved"
+
+        # elif isinstance(data, Identity):
+        #     # This is basic identity information, probably from a
+        #     # listing operation.
+        #     new_xml = PrettyElement(tag=self.root_tag)
+        #     super(Container, self).__init__(jss, new_xml)
+        #     self._basic_identity = Identity(data)
+        #     # Store any kwargs used in retrieving this object.
+        #     self.kwargs = kwargs
+
+        else:
+            raise TypeError(
+                "UAPIObjects data argument must be of type "
+                "dict")
+
+    def url(self, method='GET'):
+        """Return the path subcomponent of the url to this object.
+
+        For example: "computers/id/451"
+
+        UAPI is not consistent with the endpoint name based on which operation you are performing.
+        """
+        if hasattr(self, '_endpoint_path_' + method.lower()):
+            pass
+
+        url_components = [self._endpoint_path, self._id_path, self.id]
+        url_components.extend(self._process_kwargs(self.kwargs))
+        return os.path.join(*url_components)
+
+    @classmethod
+    def _urlify_arg(cls, key, val):
+        """Convert keyword arguments' values to proper format for GET"""
+        if key == 'subset':
+            if not isinstance(val, list):
+                val = val.split("&")
+
+            # If this is not a "basic" subset, and it's missing
+            # "general", add it in, because we need the ID.
+            if all(k not in val for k in ("general", "basic")):
+                val.append("general")
+
+            return ['subset', "&".join(val)]
+
+        elif key == 'date_range':
+            start, end = val
+            fmt = lambda s: s.strftime('%Y-%m-%d')
+            start = start if isinstance(start, basestring) else fmt(end)
+            end = end if isinstance(end, basestring) else fmt(end)
+            return ['{}_{}'.format(start, end)]
+
+        else:
+            return [key, val]
+        
+    @classmethod
+    def _process_kwargs(cls, kwargs):
+        kwarg_urls = []
+        if kwargs and all(key in cls.allowed_kwargs for key in kwargs):
+            kwargs = cls._handle_kwargs(kwargs)
+            for key, val in kwargs.items():
+                kwarg_urls.extend(cls._urlify_arg(key, val))
+        return kwarg_urls
+
+    @classmethod
+    def _handle_kwargs(cls, kwargs):
+        """Do nothing. Can be overriden by classes which need it."""
+        return kwargs

--- a/jss/uapiobjects.py
+++ b/jss/uapiobjects.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# Copyright (C) 2014-2017 Shea G Craig
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""uapiobjects.py
+
+Classes representing JSS database objects and their UAPI endpoints
+"""
+from .uapiobject import UAPIObject, UAPIContainer
+
+__all__ = ('Cache', 'MobileDevice')
+
+
+class Cache(UAPIObject):
+    _endpoint_path = "settings/obj/cache"
+    can_post = False
+    can_delete = False
+
+
+class Ebook(UAPIObject):
+    _endpoint_path = "deployable/obj/ebook"
+    can_put = False
+    can_post = False
+    can_delete = False
+
+
+class MobileDevice(UAPIObject):
+    _endpoint_path = "inventory/obj/mobileDevice"
+
+
+class AlertNotification(UAPIObject):
+    _endpoint_path = "notifications/alerts"
+    can_put = False
+    can_post = False
+
+
+class PatchPolicy(UAPIObject):
+    _endpoint_path = "patch/obj/policy"
+
+
+class EnrollmentSettings(UAPIObject):
+    _endpoint_path = "settings/obj/enrollment"
+    can_post = False
+    can_delete = False
+
+
+class SelfServiceSettings(UAPIObject):
+    _endpoint_path = "settings/obj/selfservice"
+    can_post = False
+    can_delete = False
+

--- a/jss/uapiobjects.py
+++ b/jss/uapiobjects.py
@@ -19,7 +19,8 @@ Classes representing JSS database objects and their UAPI endpoints
 """
 from .uapiobject import UAPIObject, UAPIContainer
 
-__all__ = 'Cache', 'UAPIEbook', 'AlertNotification'
+__all__ = 'Cache', 'Ebook', 'AlertNotification', 'MobileDevice', 'PatchPolicy', 'EnrollmentSettings', \
+          'EnrollmentHistory', 'SelfServiceSettings', 'SystemInformation'
 
 
 class Cache(UAPIObject):
@@ -28,36 +29,48 @@ class Cache(UAPIObject):
     can_delete = False
 
 
-class UAPIEbook(UAPIObject):
+class Ebook(UAPIContainer):
     _endpoint_path = "deployable/obj/ebook"
     can_put = False
     can_post = False
     can_delete = False
-#
-#
-# class MobileDevice(UAPIObject):
-#     _endpoint_path = "inventory/obj/mobileDevice"
-#
-#
 
-class AlertNotification(UAPIObject):
+
+class MobileDevice(UAPIObject):
+    _endpoint_path = "inventory/obj/mobileDevice"
+
+
+class AlertNotification(UAPIContainer):
     _endpoint_path = "notifications/alerts"
     can_put = False
     can_post = False
-#
-#
-# class PatchPolicy(UAPIObject):
-#     _endpoint_path = "patch/obj/policy"
-#
-#
-# class EnrollmentSettings(UAPIObject):
-#     _endpoint_path = "settings/obj/enrollment"
-#     can_post = False
-#     can_delete = False
-#
-#
-# class SelfServiceSettings(UAPIObject):
-#     _endpoint_path = "settings/obj/selfservice"
-#     can_post = False
-#     can_delete = False
 
+
+class PatchPolicy(UAPIContainer):
+    _endpoint_path = "patch/obj/policy"
+
+
+class EnrollmentSettings(UAPIObject):
+    _endpoint_path = "settings/obj/enrollment"
+    can_post = False
+    can_delete = False
+
+
+class EnrollmentHistory(UAPIContainer):
+    _endpoint_path = "settings/obj/enrollment/history"
+    can_post = False
+    can_put = False
+    can_delete = False
+
+
+class SelfServiceSettings(UAPIObject):
+    _endpoint_path = "settings/obj/selfservice"
+    can_post = False
+    can_delete = False
+
+
+class SystemInformation(UAPIObject):
+    _endpoint_path = "system/obj/info"
+    can_put = False
+    can_post = False
+    can_delete = False

--- a/jss/uapiobjects.py
+++ b/jss/uapiobjects.py
@@ -19,7 +19,7 @@ Classes representing JSS database objects and their UAPI endpoints
 """
 from .uapiobject import UAPIObject, UAPIContainer
 
-__all__ = ('Cache', 'MobileDevice')
+__all__ = 'Cache', 'UAPIEbook', 'AlertNotification'
 
 
 class Cache(UAPIObject):
@@ -28,35 +28,36 @@ class Cache(UAPIObject):
     can_delete = False
 
 
-class Ebook(UAPIObject):
+class UAPIEbook(UAPIObject):
     _endpoint_path = "deployable/obj/ebook"
     can_put = False
     can_post = False
     can_delete = False
-
-
-class MobileDevice(UAPIObject):
-    _endpoint_path = "inventory/obj/mobileDevice"
-
+#
+#
+# class MobileDevice(UAPIObject):
+#     _endpoint_path = "inventory/obj/mobileDevice"
+#
+#
 
 class AlertNotification(UAPIObject):
     _endpoint_path = "notifications/alerts"
     can_put = False
     can_post = False
-
-
-class PatchPolicy(UAPIObject):
-    _endpoint_path = "patch/obj/policy"
-
-
-class EnrollmentSettings(UAPIObject):
-    _endpoint_path = "settings/obj/enrollment"
-    can_post = False
-    can_delete = False
-
-
-class SelfServiceSettings(UAPIObject):
-    _endpoint_path = "settings/obj/selfservice"
-    can_post = False
-    can_delete = False
+#
+#
+# class PatchPolicy(UAPIObject):
+#     _endpoint_path = "patch/obj/policy"
+#
+#
+# class EnrollmentSettings(UAPIObject):
+#     _endpoint_path = "settings/obj/enrollment"
+#     can_post = False
+#     can_delete = False
+#
+#
+# class SelfServiceSettings(UAPIObject):
+#     _endpoint_path = "settings/obj/selfservice"
+#     can_post = False
+#     can_delete = False
 

--- a/jss/uapiobjects.py
+++ b/jss/uapiobjects.py
@@ -19,7 +19,7 @@ Classes representing JSS database objects and their UAPI endpoints
 """
 from .uapiobject import UAPIObject, UAPIContainer
 
-__all__ = 'Cache', 'Ebook', 'AlertNotification', 'MobileDevice', 'PatchPolicy', 'EnrollmentSettings', \
+__all__ = 'Cache', 'Ebook', 'AlertNotification', 'MobileDevice', 'PatchPolicy', 'EnrollmentSetting', \
           'EnrollmentHistory', 'SelfServiceSettings', 'SystemInformation'
 
 
@@ -38,6 +38,9 @@ class Ebook(UAPIContainer):
 
 class MobileDevice(UAPIObject):
     _endpoint_path = "inventory/obj/mobileDevice"
+    can_put = False
+    can_post = False
+    can_delete = False
 
 
 class AlertNotification(UAPIContainer):
@@ -50,7 +53,7 @@ class PatchPolicy(UAPIContainer):
     _endpoint_path = "patch/obj/policy"
 
 
-class EnrollmentSettings(UAPIObject):
+class EnrollmentSetting(UAPIObject):
     _endpoint_path = "settings/obj/enrollment"
     can_post = False
     can_delete = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,18 +56,13 @@ def jrequests(jss_prefs_dict):  # type: (dict) -> JSS
     return o
 
 
-# @pytest.fixture
-# def gurl_adapter():  # () -> GurlAdapter
-#     adapter = GurlAdapter()
-#     return adapter
-
-
 @pytest.fixture
 def requests_adapter(jss_prefs_dict):  # type: () -> RequestsAdapter
     adapter = RequestsAdapter(jss_prefs_dict['jss_url'])
     return adapter
 
-  
+
+
 @pytest.fixture
 def etree_building():  # type: () -> ElementTree.Element
     building = ElementTree.Element('building')
@@ -99,18 +94,6 @@ def dp_smb_ip_port(docker_ip, docker_services):
     return docker_ip, docker_services.port_for('samba', 139)
 
 
-
-@pytest.fixture
-def gurl_jss(gurl_adapter, jss_prefs_dict):  # type: (GurlAdapter, dict) -> JSS
-    j = JSS(
-        adapter=gurl_adapter,
-        url=jss_prefs_dict['jss_url'],
-        user=jss_prefs_dict['jss_user'],
-        password=jss_prefs_dict['jss_password'],
-        ssl_verify=jss_prefs_dict['verify'],
-    )
-    return j
-
 # @pytest.fixture
 # def dp_afp_url(docker_ip, docker_services):
 #     afp_url = 'afp://%s:%s/distribution_point' % (
@@ -122,3 +105,8 @@ def gurl_jss(gurl_adapter, jss_prefs_dict):  # type: (GurlAdapter, dict) -> JSS
 #         check=lambda: is_afp_responsive(afp_url)
 #     )
 #     return afp_url
+
+@pytest.fixture
+def uapi_token(jss_prefs_dict, j):
+    response = j.post('uapi/auth/tokens', data={})
+    json_data = response.json()

--- a/tests/test_uapiobjects.py
+++ b/tests/test_uapiobjects.py
@@ -1,5 +1,5 @@
 import pytest
-from jss import JSS
+from jss import JSS, uapiobjects
 from UserDict import UserDict
 
 
@@ -11,9 +11,27 @@ class TestUAPIObjects(object):
         assert result is not None
         assert isinstance(result, UserDict)
 
+    def test_put_cache(self, j):
+        # type: (JSS) -> None
+        cache = uapiobjects.Cache(j, {
+            "name": "Cache Fixture Configuration"
+        })
+        # cache["name"] = "Cache Fixture Configuration"
+        # cache["cacheType"] = "ehcache"
+        # cache["timeToLiveSeconds"] = 120
+        # cache["timeToIdleSeconds"] = 120
+
+        r = cache.save()
+
     def test_get_ebook(self, j):
         # type: (JSS) -> None
         result = j.uapi.Ebook()
+        assert result is not None
+        assert isinstance(result, list)
+
+    def test_get_mobiledevices(self, j):
+        # type: (JSS) -> None
+        result = j.uapi.MobileDevice()
         assert result is not None
         assert isinstance(result, list)
 

--- a/tests/test_uapiobjects.py
+++ b/tests/test_uapiobjects.py
@@ -1,11 +1,24 @@
 import pytest
 from jss import JSS
+from UserDict import UserDict
 
 
 class TestUAPIObjects(object):
 
-    def test_get_cache(self, j, uapi_token):
+    def test_get_cache(self, j):
         # type: (JSS) -> None
         result = j.Cache()
         assert result is not None
-        assert isinstance(result, dict)
+        assert isinstance(result, UserDict)
+
+    def test_get_ebook(self, j):
+        # type: (JSS) -> None
+        result = j.UAPIEbook()
+        assert result is not None
+        assert isinstance(result, list)
+
+    def test_get_notifications(self, j):
+        # type: (JSS) -> None
+        result = j.AlertNotification()
+        assert result is not None
+        assert isinstance(result, list)

--- a/tests/test_uapiobjects.py
+++ b/tests/test_uapiobjects.py
@@ -1,0 +1,11 @@
+import pytest
+from jss import JSS
+
+
+class TestUAPIObjects(object):
+
+    def test_get_cache(self, j, uapi_token):
+        # type: (JSS) -> None
+        result = j.Cache()
+        assert result is not None
+        assert isinstance(result, dict)

--- a/tests/test_uapiobjects.py
+++ b/tests/test_uapiobjects.py
@@ -7,18 +7,27 @@ class TestUAPIObjects(object):
 
     def test_get_cache(self, j):
         # type: (JSS) -> None
-        result = j.Cache()
+        result = j.uapi.Cache()
         assert result is not None
         assert isinstance(result, UserDict)
 
     def test_get_ebook(self, j):
         # type: (JSS) -> None
-        result = j.UAPIEbook()
+        result = j.uapi.Ebook()
         assert result is not None
         assert isinstance(result, list)
 
     def test_get_notifications(self, j):
         # type: (JSS) -> None
-        result = j.AlertNotification()
+        result = j.uapi.AlertNotification()
         assert result is not None
         assert isinstance(result, list)
+
+    def test_get_enrollment_settings(self, j):
+        # type: (JSS) -> None
+        result = j.uapi.EnrollmentSetting()
+
+    def test_get_system_info(self, j):
+        # type: (JSS) -> None
+        result = j.uapi.SystemInformation()
+        assert result is not None


### PR DESCRIPTION
This PR includes cherry picked commits relating to uapi support.

Due to some assumptions in the JSS object about XML request and response data, the original API has been wrapped in a way that maintains backwards compatibility whilst allowing developers to supply parameters to force json for UAPI endpoints. An authentication adapter was added for UAPI because even though UAPI token endpoints use Basic, they don't supply a header to indicate as such.