### PR TITLE
Modify TLS support for recent versions of JSS

### DIFF
--- a/jss/tlsadapter.py
+++ b/jss/tlsadapter.py
@@ -73,5 +73,5 @@ class TLSAdapter(HTTPAdapter):
         """Set up a poolmanager to use TLS and our cipher list."""
         self.poolmanager = PoolManager(
             num_pools=connections, maxsize=maxsize, block=block,
-            ssl_version=ssl.PROTOCOL_TLSv1)   # pylint: disable=no-member
+            ssl_version=ssl.PROTOCOL_TLSv1_2)   # pylint: disable=no-member
         pyopenssl.DEFAULT_SSL_CIPHER_LIST = CIPHER_LIST


### PR DESCRIPTION
This complex, 2-character modification allows `python-jss` to communicate with recent versions of the JSS after updates to Jamf's TLS support.