### PR TITLE
Fixed missing urllib quote module and python2 compatibility

### DIFF
--- a/jss/distribution_point.py
+++ b/jss/distribution_point.py
@@ -44,12 +44,12 @@ except ImportError:
 
 # 2 and 3 compatible
 try:
-    from urllib.parse import urlparse, urlencode, unquote
+    from urllib.parse import urlparse, urlencode, unquote, quote
     from urllib.request import urlopen, Request
     from urllib.error import HTTPError
 except ImportError:
     from urlparse import urlparse
-    from urllib import urlencode, unquote
+    from urllib import urlencode, unquote, quote
     from urllib2 import urlopen, Request, HTTPError
 
 from . import casper
@@ -353,7 +353,7 @@ class MountedRepository(FileRepository):
         results = set()
         join = os.path.join
         url = self.connection["url"]
-        share_name = urllib.quote(self.connection["share_name"],
+        share_name = quote(self.connection["share_name"],
                                   safe="~()*!.'")
         port = self.connection["port"]
 
@@ -428,7 +428,7 @@ class MountedRepository(FileRepository):
     @property
     def _encoded_password(self):
         """Returns the safely url-quoted password for this DP."""
-        return urllib.quote(self.connection["password"], safe="~()*!.'")
+        return quote(self.connection["password"], safe="~()*!.'")
 
 
 class AFPDistributionPoint(MountedRepository):


### PR DESCRIPTION
I came across a problem with the recent version of python-jss which was breaking certain AutoPkg/JSSImporter runs:

```
JSSImporter: python-jss version: 2.0.1.
JSSImporter: JSSImporter version: 1.0.2b3.
global name 'urllib' is not defined
Failed.
```

I did a global search of the `python-jss` project and the only direct call to `urllib` is in `distribution_point.py`. Looking at that file, `urllib.quote` is being called but there is no `import urllib` statement, so that won't work (using python2). 

So I made a minor change to this file, adding `quote` as a module, and changing `urllib.quote` to `quote`. This fixed the problem of running the recipes on a Mac using python2.

@mosen, could you verify that it is correct for python3? I made the assumption that `quote` is in `urllib.parse` since `unquote` is...but I have also learned never to assume anything :) 