### PR TITLE
Changed ElementTree.tostring to return unicode string

### DIFF
--- a/jss/tools.py
+++ b/jss/tools.py
@@ -156,7 +156,7 @@ def element_str(elem):
     # deepcopy so we don't mess with the valid XML.
     pretty_data = copy.deepcopy(elem)
     indent_xml(pretty_data)
-    return ElementTree.tostring(pretty_data, encoding='UTF-8')
+    return ElementTree.tostring(pretty_data, encoding='unicode')
 
 
 def quote_and_encode(string):


### PR DESCRIPTION
Current it returns bytes and results in an error. Fixes https://github.com/jssimporter/python-jss/issues/97