### PR TITLE
make raw_input forward-compatible with py3

### DIFF
--- a/jss/jss_prefs.py
+++ b/jss/jss_prefs.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 from __future__ import absolute_import
 import getpass
+from six.moves import input as raw_input
 import os
 import readline   # pylint: disable=unused-import
 import subprocess

--- a/jss/tools.py
+++ b/jss/tools.py
@@ -22,6 +22,7 @@ Helper functions for python-jss.
 from __future__ import absolute_import
 import copy
 from functools import wraps
+from six.moves import input as raw_input
 import os
 import re
 try:


### PR DESCRIPTION
update files in the project that had used py2-only raw_input, test_jssprefs.py also makes reference but doesn't seem to call it directly. Doesn't exactly use prescribed fix, but got idea from a related [stackoverflow](https://stackoverflow.com/questions/954834/how-do-i-use-raw-input-in-python-3#comment94391999_31687067), addresses #101 