### PR TITLE
Pass file object to requests post

### DIFF
--- a/jss/distribution_point.py
+++ b/jss/distribution_point.py
@@ -658,7 +658,7 @@ class DistributionServer(Repository):
                    "FILE_TYPE": file_type, "FILE_NAME": basefname}
         response = self.connection["jss"].session.post(
             url=self.connection["upload_url"],
-            data=resource.read(),
+            data=resource,
             headers=headers)
         if self.connection["jss"].verbose:
             print(response)
@@ -680,7 +680,7 @@ class DistributionServer(Repository):
                    "fileIdentifier": "FIELD_FILE_NAME_FOR_DIST_POINTS"}
         response = self.connection["jss"].session.post(
             url=self.connection["upload_url"],
-            data=resource.read(),
+            data=resource,
             headers=headers)
         print(response)
         if self.connection["jss"].verbose:


### PR DESCRIPTION
Instead of reading a file's content in the call to post(), simply pass
the file object.  This resolves an issue with files larger than 2GB
where resource.read() would trigger an error of "string longer than
2147483647 bytes."

Fixes #106