### PR TITLE
'unicode' is not an encoding that ElementTree understands

### DIFF
--- a/jss/tools.py
+++ b/jss/tools.py
@@ -157,7 +157,7 @@ def element_str(elem):
     # deepcopy so we don't mess with the valid XML.
     pretty_data = copy.deepcopy(elem)
     indent_xml(pretty_data)
-    return ElementTree.tostring(pretty_data, encoding='unicode')
+    return ElementTree.tostring(pretty_data, encoding='UTF_8')
 
 
 def quote_and_encode(string):


### PR DESCRIPTION
Switched this to 'UTF_8' as ElementTree returns errors otherwise:

File "/usr/lib/python2.7/xml/etree/ElementTree.py" in encode
  843.         return text.encode(encoding)

Exception Type: LookupError at /jssmanifests/xml/0A743BE2-08AD-5DD1-B8D8-4F64FB27483E
Exception Value: unknown encoding: unicode

